### PR TITLE
Fallback to /usr/lib/os-release; win32/darwin compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,5 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+* Check for /usr/lib/os-release in addition to /etc/os-release
+
 ## [1.0.0] - 2018-02-10
 * First public version

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linux-os-info",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Get Linux release info (distribution name, version, arch, release, etc.) from '/etc/os-release' file and from native os module. On Windows and Macs it returns only node os module info (platform, hostname, release and arch)",
   "main": "index.js",
   "scripts": {

--- a/test/test.js
+++ b/test/test.js
@@ -11,7 +11,12 @@ let osData = {
   release: os.release(),
 }
 
-let osRelease = fs.readFileSync('/etc/os-release', 'utf8')
+let osRelease
+if (os.type() === 'Linux') {
+    osRelease = fs.readFileSync('/etc/os-release', 'utf8')
+} else {
+    osRelease = ''
+}
 let lines = osRelease.split('\n')
 
 // use different logic to determine the KV pairs


### PR DESCRIPTION
This PR does a couple things:

- When `/etc/os-release` doesn't exist (or cannot be read), it falls back to reading `/usr/lib/os-release`. This is behaviour as documented in https://www.freedesktop.org/software/systemd/man/os-release.html
- Fixes running on non-linux systems. The current code throws a `ReferenceError: resolve is undefined` error when non running on a linux box.